### PR TITLE
Fix skill folder for skills from repo

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -163,6 +163,8 @@ class MycroftSkillsManager(object):
             skills.append(name)
             url = module.split('url = ')[1].strip()
             skill_folder = url.split("/")[-1]
+            if skill_folder[-4:] == '.git':
+                skill_folder = skill_folder[:-4]
             skill_path = join(self.skills_dir, skill_folder)
             skill_id = hash(skill_path)
             skill_author = url.split("/")[-2]


### PR DESCRIPTION
Not sure if this messes with an intended structure but I found it weird that the skill directory for skills on the repo ended in `.git`.

This removes the .git from the folder so it matches the local skills.